### PR TITLE
fix(SpotifyCard): handle progress race conditions

### DIFF
--- a/src/components/SpotifyCard.svelte
+++ b/src/components/SpotifyCard.svelte
@@ -13,10 +13,14 @@ lanyard.subscribe(data => {
 });
 
 setInterval(() => {
-   if (spotify !== null) {
+   if (spotify != null) {
       let songLength = spotify.timestamps.end - spotify.timestamps.start;
       let calcSeconds = Date.now() - spotify.timestamps.start;
       elapsed = calcSeconds / songLength;
+      
+      // calcSeconds is affected by Date.now().
+      // The Spotify API sometimes fails to update its state back to null - so we're adding a failsafe.
+      if (Math.ceil(elapsed)) elapsed = 1;
    } 
 }, 1000);
 


### PR DESCRIPTION
This should resolve the media player progress bar overflowing and increasing in width by doing two things:

- We're using a truthy negated expression instead of an absolute negate expression. (`!=` vs. `!==`)
- We're adding a failsafe condition to apply a limit to the media player when the Spotify API forgets to update us back to `null`. (This is also using Lanyard, so it could be an issue with that as well)